### PR TITLE
expirationHandler not being called FIX

### DIFF
--- a/ios/ZingoMobile/AppDelegate.m
+++ b/ios/ZingoMobile/AppDelegate.m
@@ -324,10 +324,7 @@ static BGProcessingTask *bgTask = nil;
     NSLog(@"BGTask startBackgroundTask run sync task");
     syncFinished = false;
     [NSThread detachNewThreadSelector:@selector(syncingProcessBackgroundTask:) toTarget:self withObject:nil];
-    [self syncingStatusProcessBackgroundTask:nil];
 
-    // this trigger doesn't work, but if in some point works
-    // it finish the task properly.
     __weak BGTask* weakTask = bgTask;
     bgTask.expirationHandler = ^{
         NSLog(@"BGTask startBackgroundTask expirationHandler called");


### PR DESCRIPTION
Explained:

`[NSThread detachNewThreadSelector:` spins up a thread and fires the selector. So this is actually enough and what was supposed to be done.

Yet another sync was fired with `[self syncingStatusProcessBackgroundTask:nil];` on the next line, causing 2 threads working at the same time on the same task. ExpirationHandler was set twice causing the first one to be overridden so when system called the expirationHandler, the value was nil. It's all because the ID and the BGTask are unique, so the system tries to call the first handler and not the 2nd one. Also, even if system calls the 2nd expirationHandler, it wouldn't work becuase `[self syncingStatusProcessBackgroundTask:nil];` is fired on a main thread and while loop is blocking it. I experienced the same issue when I was debugging BGTasks in both objc/swift.

Another possible solution would be to use GCD, like this:
```
dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
     [self syncingStatusProcessBackgroundTask:nil];
});
```

This approach leans away from using NSThreads, rely on GCD and spins up exactly one sync with expirationHandler being valid value.