### PR TITLE
Dev ios native b64 write wallet fixed

### DIFF
--- a/ios/RPCModule.swift
+++ b/ios/RPCModule.swift
@@ -163,19 +163,13 @@ class RPCModule: NSObject {
 
   @objc(deleteExistingWalletBackup:reject:)
   func deleteExistingWalletBackup(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-      if let documentsDirectory = paths.first {
-        let fileName = "\(documentsDirectory)/wallet.backup.dat.txt"
-        do {
-            try FileManager.default.removeItem(atPath: fileName)
-            resolve("true")
-        } catch {
-            NSLog("Error deleting backup wallet \(error.localizedDescription)")
-            resolve("false")
-        }
-      } else {
-        NSLog("Error deleting backup wallet")
-        resolve("false")
+      let filename = get_filename("wallet.backup.dat.txt")
+      do {
+          try FileManager.default.removeItem(atPath: fileName)
+          resolve("true")
+      } catch {
+          NSLog("Error deleting backup wallet \(error.localizedDescription)")
+          resolve("false")
       }
   }
 

--- a/ios/RPCModule.swift
+++ b/ios/RPCModule.swift
@@ -31,6 +31,7 @@ class RPCModule: NSObject {
           NSLog("Error fetching filename: \(errorMessage)")
           NSLog("Directory type attempted: \(dirType)")
           NSLog("Domain mask attempted: \(domainMask)")
+          throw error
       } catch {
           NSLog("An unexpected error occurred while fetching the filename.")
           throw error


### PR DESCRIPTION
Experiment with helpers to DRY file access code.

This eliminates some redundant code, and makes all the filename access errors be reported in a detailed and uniform way.   We can add an optional arg to `get_filename` or use introspection to have it also log the calling function name if that's a requirement.   I can add that later today.

I don't have a swift environment running so this code is *not* tested! 